### PR TITLE
Set max split to 1 for the full_name list to return to 2 elements max…

### DIFF
--- a/external_modules/gazu/person.py
+++ b/external_modules/gazu/person.py
@@ -73,7 +73,7 @@ def get_person_by_full_name(full_name, client=default):
         dict: Person corresponding to given name.
     """
     if " " in full_name:
-        first_name, last_name = full_name.lower().split(" ")
+        first_name, last_name = full_name.lower().split(" ",1)
     else:
         first_name, last_name = full_name.lower().strip(), ""
     for person in all_persons():


### PR DESCRIPTION
… so not error out when more than 2 names are retrieved (eg. first, middle, last) to be [first, middle last].